### PR TITLE
Allow arn to be defined in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,16 @@ steps:
         role: arn:aws:iam::123456789012:role/example-role
 ```
 
-Alternatively,
+Alternatively, you could specify `AWS_ASSUME_ROLE_ARN` in your environment
 
 ```yaml
 steps:
   - command: bin/ci-aws-thing
+    env:
+      AWS_ASSUME_ROLE_ARN: arn:aws:iam::123456789012:role/example-role
     plugins:
-      cultureamp/aws-assume-role:
-        env: ROLE_ARN
+      cultureamp/aws-assume-role
 ```
-
-where `ROLE_ARN` is defined on execution (e.g. `ROLE_ARN=arn:aws:iam::123456789012:role/example-role`)
 
 Options
 -------
@@ -37,10 +36,6 @@ Options
 ### `role`
 
 The ARN of the IAM Role to assume. The build agent must already be authenticated (e.g. EC2 instance role) and have `sts:AssumeRole` permission for the role being assumed.
-
-### `env`
-
-The environment variable name which holds the ARN of the IAM Role to assume.
 
 References
 ----------

--- a/README.md
+++ b/README.md
@@ -19,12 +19,28 @@ steps:
         role: arn:aws:iam::123456789012:role/example-role
 ```
 
+Alternatively,
+
+```yaml
+steps:
+  - command: bin/ci-aws-thing
+    plugins:
+      cultureamp/aws-assume-role:
+        env: ROLE_ARN
+```
+
+where `ROLE_ARN` is defined on execution (e.g. `ROLE_ARN=arn:aws:iam::123456789012:role/example-role`)
+
 Options
 -------
 
 ### `role`
 
 The ARN of the IAM Role to assume. The build agent must already be authenticated (e.g. EC2 instance role) and have `sts:AssumeRole` permission for the role being assumed.
+
+### `env`
+
+The environment variable name which holds the ARN of the IAM Role to assume.
 
 References
 ----------

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -4,12 +4,8 @@ set -o pipefail
 set -u
 
 main() {
-  local env_name="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ENV:-"DEFAULT_ROLE"}"
-  local default_role=${!env_name:-}
-  local role="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-$default_role}"
+  local role="${AWS_ASSUME_ROLE_ARN:-${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-}}"
   local build="${BUILDKITE_BUILD_NUMBER:-}"
-
-  echo "role: ${role}"
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
@@ -20,7 +16,7 @@ main() {
     echo "  AWS_SECRET_ACCESS_KEY=(${#AWS_SECRET_ACCESS_KEY} chars)"
     echo "  AWS_SESSION_TOKEN=(${#AWS_SESSION_TOKEN} chars)"
   else
-    echo >&2 "Missing BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE or BUILDKITE_BUILD_NUMBER or $env_name"
+    echo >&2 "Missing BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE or BUILDKITE_BUILD_NUMBER or AWS_ASSUME_ROLE_ARN"
   fi
 }
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -4,8 +4,12 @@ set -o pipefail
 set -u
 
 main() {
-  local role="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-}"
+  local env_name="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ENV:-"DEFAULT_ROLE"}"
+  local default_role=${!env_name:-}
+  local role="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-$default_role}"
   local build="${BUILDKITE_BUILD_NUMBER:-}"
+
+  echo "role: ${role}"
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
@@ -16,7 +20,7 @@ main() {
     echo "  AWS_SECRET_ACCESS_KEY=(${#AWS_SECRET_ACCESS_KEY} chars)"
     echo "  AWS_SESSION_TOKEN=(${#AWS_SESSION_TOKEN} chars)"
   else
-    echo >&2 "Missing BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE or BUILDKITE_BUILD_NUMBER"
+    echo >&2 "Missing BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE or BUILDKITE_BUILD_NUMBER or $env_name"
   fi
 }
 


### PR DESCRIPTION
This allows the ARN to be pulled from the specified ENV variable on execution.

Although ENV variables can be interpolated in pipeline definition file, they are evaluated when the file is uploaded. This prevents variables set during the build from being read. (e.g. block step meta-data)