### PR TITLE
Fail fast and clearly when AssumeRole fails.

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 set -u

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,7 +9,8 @@ main() {
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
-    eval "$(assume_role_credentials "$role" "$build" | credentials_json_to_shell_exports)"
+    local exports; exports="$(assume_role_credentials "$role" "$build" | credentials_json_to_shell_exports)"
+    eval "$exports"
 
     echo "Exported session credentials:"
     echo "  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -10,9 +10,10 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE="role123"
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --query Credentials : cat tests/sts.json"
-  
+
   run $PWD/hooks/pre-command
-  
+
+  assert_output --partial "~~~ Assuming IAM role role123 ..."
   assert_output --partial "Exported session credentials"
   assert_output --partial "AWS_ACCESS_KEY_ID=baz"
   assert_output --partial "AWS_SECRET_ACCESS_KEY=(3 chars)"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -22,3 +22,20 @@ load "$BATS_PATH/load.bash"
   assert_success
   unstub aws
 }
+
+@test "failure to assume role" {
+  export BUILDKITE_BUILD_NUMBER="42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE="role123"
+
+  stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --query Credentials : echo 'Not authorized to perform sts:AssumeRole' >&2; false"
+
+  run $PWD/hooks/pre-command
+
+  assert_output <<EOF
+~~~ Assuming IAM role role123 ...
+Not authorized to perform sts:AssumeRole
+EOF
+  assert_failure
+
+  unstub aws
+}


### PR DESCRIPTION
Before:

    Assuming IAM role arn:aws:iam::123412341234:role/foo-bar ...
    
    An error occurred (AccessDenied) when calling the AssumeRole operation: Not authorized to perform sts:AssumeRole
    Exported session credentials:
    /var/lib/buildkite-agent/plugins/github-com-cultureamp-aws-assume-role-buildkite-plugin/hooks/pre-command: line 15: AWS_ACCESS_KEY_ID: unbound variable

After:

    Assuming IAM role arn:aws:iam::123412341234:role/foo-bar ...
    
    An error occurred (AccessDenied) when calling the AssumeRole operation: Not authorized to perform sts:AssumeRole