### PR TITLE
Add support for specifying the role assumption duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,17 @@ Options
 
 The ARN of the IAM Role to assume. The build agent must already be authenticated (e.g. EC2 instance role) and have `sts:AssumeRole` permission for the role being assumed.
 
+### `duration` (optional)
+
+The duration (in seconds) to assume the role for. Defaults to 3600 (1 hour).
+
 References
 ----------
 
 * [Creating a Role to Delegate Permissions to an IAM User](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html)
 * [Requesting Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 * [AWS STS AssumeRole API](http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+* [Checking the Maximum Session Duration for a Role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
 
 License
 -------

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,10 +6,11 @@ set -u
 main() {
   local role="${AWS_ASSUME_ROLE_ARN:-${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-}}"
   local build="${BUILDKITE_BUILD_NUMBER:-}"
+  local duration="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_DURATION:-3600}"
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
-    local exports; exports="$(assume_role_credentials "$role" "$build" | credentials_json_to_shell_exports)"
+    local exports; exports="$(assume_role_credentials "$role" "$build" "$duration" | credentials_json_to_shell_exports)"
     eval "$exports"
 
     echo "Exported session credentials:"
@@ -21,7 +22,7 @@ main() {
   fi
 }
 
-# Assume the IAM role $1, allocate a session name derived from $2.
+# Assume the IAM role $1, for duration $3, and allocate a session name derived from $2.
 # output: the Credentials portion of the AWS response JSON;
 #     {
 #         "SecretAccessKey": "foo"
@@ -32,9 +33,11 @@ main() {
 assume_role_credentials() {
   local role="$1"
   local build="$2"
+  local duration="$3"
   aws sts assume-role \
     --role-arn "$role" \
     --role-session-name "aws-assume-role-buildkite-plugin-${build}" \
+    --duration-seconds "$duration" \
     --query Credentials
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,8 @@ requirements:
   - aws
 configuration:
   properties:
+    duration:
+      type: string
     role:
       type: string
   required:


### PR DESCRIPTION
AWS now supports assumption of roles for longer than the previous limit of 1 hour. We have a small number of jobs that are quite long running, and would like to be able to assume roles for longer than 1 hour.

This PR adds an optional parameter for `duration` that is passed to the role assumption command as `--duration-seconds`.

Repository tests, plus my own testing in BuildKite yields positive results.