### PR TITLE
Allow passing in a custom region

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The ARN of the IAM Role to assume. The build agent must already be authenticated
 
 The duration (in seconds) to assume the role for. Defaults to 3600 (1 hour).
 
+### `region` (optional)
+
+Exports `AWS_REGION` and `AWS_DEFAULT_REGION` with the value you set. If not set the values of AWS_REGION and AWS_DEFAULT_REGION will not be changed.
+
+Development
+-----------
+
+Tests are written using bats with bats-mock and a docker compose file is provided to simplify testing.
+To run tests: `docker-compose run tests`
+
 References
 ----------
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -7,6 +7,7 @@ main() {
   local role="${AWS_ASSUME_ROLE_ARN:-${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE:-}}"
   local build="${BUILDKITE_BUILD_NUMBER:-}"
   local duration="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_DURATION:-3600}"
+  local region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_REGION:-""}"
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
@@ -17,6 +18,14 @@ main() {
     echo "  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
     echo "  AWS_SECRET_ACCESS_KEY=(${#AWS_SECRET_ACCESS_KEY} chars)"
     echo "  AWS_SESSION_TOKEN=(${#AWS_SESSION_TOKEN} chars)"
+
+    if [[ -n $region ]]; then
+      export AWS_REGION="$region"
+      export AWS_DEFAULT_REGION="$region"
+      echo "  AWS_REGION=$AWS_REGION"
+      echo "  AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+    fi
+
   else
     echo >&2 "Missing BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE or BUILDKITE_BUILD_NUMBER or AWS_ASSUME_ROLE_ARN"
   fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,6 +9,8 @@ configuration:
       type: string
     role:
       type: string
+    region:
+      type: string
   required:
     - role
   additionalProperties: false

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -72,3 +72,16 @@ EOF
   assert_output --partial "AWS_REGION=eu-central-1"
 
 }
+
+@test "does not pass in a custom region" {
+  export BUILDKITE_BUILD_NUMBER="42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE="role123"
+
+  stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : cat tests/sts.json"
+
+  run $PWD/hooks/pre-command
+  assert_output --partial "~~~ Assuming IAM role role123 ..."
+  refute_output --partial "AWS_DEFAULT_REGION="
+  refute_output --partial "AWS_REGION="
+
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -71,6 +71,8 @@ EOF
   assert_output --partial "AWS_DEFAULT_REGION=eu-central-1"
   assert_output --partial "AWS_REGION=eu-central-1"
 
+  assert_success
+  unstub aws
 }
 
 @test "does not pass in a custom region" {
@@ -83,5 +85,8 @@ EOF
   assert_output --partial "~~~ Assuming IAM role role123 ..."
   refute_output --partial "AWS_DEFAULT_REGION="
   refute_output --partial "AWS_REGION="
+
+  assert_success
+  unstub aws
 
 }

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -58,3 +58,17 @@ EOF
   assert_success
   unstub aws
 }
+
+@test "passes in a custom region" {
+  export BUILDKITE_BUILD_NUMBER="42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_ROLE="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_REGION="eu-central-1"
+
+  stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : cat tests/sts.json"
+
+  run $PWD/hooks/pre-command
+  assert_output --partial "~~~ Assuming IAM role role123 ..."
+  assert_output --partial "AWS_DEFAULT_REGION=eu-central-1"
+  assert_output --partial "AWS_REGION=eu-central-1"
+
+}


### PR DESCRIPTION
This Pr adds in a option to allow setting the AWS region environment variables through this plugin.

When using buildkite-elastic the global environment hook appears to overwrite the AWS_REGION env variables meaning if they are set in the `env:` section of a step they get overwritten by the agent to the region the agent is running in.

This means when assuming roles across accounts the CLI and API will default to the wrong region endpoints unless they are explicitly set on each command.

As plugins are loaded after all the global hook stuff happens and just before the actual command is run setting them here will get them back to the expected state, and let the commands run as expected with no additional code changes.

References: 
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
this: https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/conf/bin/bk-install-elastic-stack.sh#L60
https://github.com/buildkite/elastic-ci-stack-for-aws/blob/ea28f200832bae9208288dfe031c9ef9c7a2e577/packer/conf/buildkite-agent/hooks/environment#L8