### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Example
 steps:
   - command: bin/ci-aws-thing
     plugins:
-      cultureamp/aws-assume-role#v0.1.0:
-        role: "arn:aws:iam::123456789012:role/example-role"
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: "arn:aws:iam::123456789012:role/example-role"
 ```
 
 Alternatively, you could specify `AWS_ASSUME_ROLE_ARN` in your environment
@@ -27,7 +27,7 @@ steps:
     env:
       AWS_ASSUME_ROLE_ARN: arn:aws:iam::123456789012:role/example-role
     plugins:
-      cultureamp/aws-assume-role
+      - cultureamp/aws-assume-role
 ```
 
 Options


### PR DESCRIPTION
Hi @pda! 😊

We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.