### PR TITLE
Move pre-command hook to environment hook

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: ":shell: Lint"
     plugins:
       plugin-linter#v2.0.0:
-        id: cultureamp/aws-assume-role
+        id: weillcomecollection/aws-assume-role
 
   - label: ":shell: Tests"
     plugins:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example
 steps:
   - command: bin/ci-aws-thing
     plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
+      - wellcomecollection/aws-assume-role#v0.2.0:
           role: "arn:aws:iam::123456789012:role/example-role"
 ```
 
@@ -27,7 +27,7 @@ steps:
     env:
       AWS_ASSUME_ROLE_ARN: arn:aws:iam::123456789012:role/example-role
     plugins:
-      - cultureamp/aws-assume-role
+      - wellcomecollection/aws-assume-role
 ```
 
 Options

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -11,7 +11,7 @@ load "$BATS_PATH/load.bash"
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : cat tests/sts.json"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
 
   assert_output --partial "~~~ Assuming IAM role role123 ..."
   assert_output --partial "Exported session credentials"
@@ -29,7 +29,7 @@ load "$BATS_PATH/load.bash"
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : echo 'Not authorized to perform sts:AssumeRole' >&2; false"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
 
   assert_output <<EOF
 ~~~ Assuming IAM role role123 ...
@@ -47,7 +47,7 @@ EOF
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 43200 --query Credentials : cat tests/sts.json"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
 
   assert_output --partial "~~~ Assuming IAM role role123 ..."
   assert_output --partial "Exported session credentials"
@@ -66,7 +66,7 @@ EOF
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : cat tests/sts.json"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
   assert_output --partial "~~~ Assuming IAM role role123 ..."
   assert_output --partial "AWS_DEFAULT_REGION=eu-central-1"
   assert_output --partial "AWS_REGION=eu-central-1"
@@ -81,7 +81,7 @@ EOF
 
   stub aws "sts assume-role --role-arn role123 --role-session-name aws-assume-role-buildkite-plugin-42 --duration-seconds 3600 --query Credentials : cat tests/sts.json"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
   assert_output --partial "~~~ Assuming IAM role role123 ..."
   refute_output --partial "AWS_DEFAULT_REGION="
   refute_output --partial "AWS_REGION="


### PR DESCRIPTION
We need this to work with https://github.com/buildkite-plugins/ecr-buildkite-plugin which runs as an environment (as pre-command this will always run after and thus logging into ECR will not used the assumed credentials).