### PR TITLE
Integrate with Backstage (Modify Me!)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,30 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: aws-assume-role-buildkite-plugin
+  description: 
+  links:
+    - title: Website
+      url: https://github.com/cultureamp/aws-assume-role-buildkite-plugin
+  # - title: Confluence
+  #   url: confluence.com/project-page
+  # - title: Monitoring Dashboard
+  #   url: datadog.com/this-service
+  # - title: Logs
+  #   url: splunk.com/service?filters
+  tags: # required and based on - https://cultureamp.atlassian.net/wiki/spaces/CPlatform/pages/1720156463/Authentication+-+One+Platform+Technical+Canvas
+    - tier-1
+  annotations:
+    github.com/project-slug: cultureamp/aws-assume-role-buildkite-plugin
+    github.com/team-slug: cultureamp/sre 
+    backstage.io/techdocs-ref: url:https://github.com/cultureamp/blob/master/aws-assume-role-buildkite-plugin
+    buildkite.com/project-slug: culture-amp/aws-assume-role-buildkite-plugin
+    # pagerduty.com/integration-key: optional
+spec:
+  type: default
+  owner: sre
+  # system: 
+  # subcomponentOf: 
+  # consumesApis: 
+  # providesApis: 
+  lifecycle: production

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: ''
+site_description: ''
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Overview:
+    - Placeholder: 'index.md'


### PR DESCRIPTION
The purpose of this PR is to add the configuration required such that your component can be registered in our software catalogue - <link to backstage> (Access)

It is strongly recommended you review and change this PR.
Please consult the backstage docs and reach out to Mark Walford or the central SRE team #team_sre with any questions

This PR does the following.

1. Adds a `catalog-info.yaml` file. This file contains metadata about the repo and is read by backstage when the component is registered.
2. Adds a `mkdocs.yml` file. This file defines the backstage techdocs nav and document location (usually ./docs this folder is created if it does not already exist)
  Consult the cultureamp/backstage repo for an example https://github.com/cultureamp/backstage/blob/development/mkdocs.yml
3. Adds a github workflow that compiles the docs in the repo and pushes them to s3 for consumption from backstage

Notes:

- The `catalog-info.yaml` is not complete. Consult the backstage docs to complete accurately
- The doc workflow will not work until either 1) We add org wide aws access secrets to github actions for consumption or 2) A buildkite pipeline step is added that executes this workflow passing aws access secrets. In both cases this workflow will still be used to publish the docs.