### PR TITLE
Allow externalId for assumed role

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The duration (in seconds) to assume the role for. Defaults to 3600 (1 hour).
 
 Exports `AWS_REGION` and `AWS_DEFAULT_REGION` with the value you set. If not set the values of AWS_REGION and AWS_DEFAULT_REGION will not be changed.
 
+### `externalId` (optional)
+
+Used to pass through an externalId to the `sts:AssumeRole` command. This is used for assuming a role within another AWS account.
+
 Development
 -----------
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -8,10 +8,11 @@ main() {
   local build="${BUILDKITE_BUILD_NUMBER:-}"
   local duration="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_DURATION:-3600}"
   local region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_REGION:-""}"
+  local externalId="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_EXTERNALID:-""}"
 
   if [[ -n $role && -n $build ]]; then
     echo "~~~ Assuming IAM role $role ..."
-    local exports; exports="$(assume_role_credentials "$role" "$build" "$duration" | credentials_json_to_shell_exports)"
+    local exports; exports="$(assume_role_credentials "$role" "$build" "$duration" "$externalId" | credentials_json_to_shell_exports)"
     eval "$exports"
 
     echo "Exported session credentials:"
@@ -43,11 +44,21 @@ assume_role_credentials() {
   local role="$1"
   local build="$2"
   local duration="$3"
-  aws sts assume-role \
-    --role-arn "$role" \
-    --role-session-name "aws-assume-role-buildkite-plugin-${build}" \
-    --duration-seconds "$duration" \
+  local externalId="$4"
+
+  params=(
+    --role-arn "$role"
+    --role-session-name "aws-assume-role-buildkite-plugin-${build}"
+    --duration-seconds "$duration"
     --query Credentials
+  )
+
+  # Only add the externalId param if it exists - if it doesn't exist and we send empty string, AWS throws an error.
+  if [[ "$externalId" != "" ]]; then
+      params+=(--external-id "$externalId")
+  fi
+
+  aws sts assume-role "${params[@]}"
 }
 
 # Convert credentials JSON to shell export statements using standard CLI tools

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,6 +11,8 @@ configuration:
       type: string
     region:
       type: string
+    externalId:
+      type: string
   required:
     - role
   additionalProperties: false


### PR DESCRIPTION
When assuming a role, an external-id can be provided. This is used for assuming a role within a different AWS account.

Currently, this plugin does not support the external ID parameter.

Also included here is a change for how the parameters are passed through to STS. The external-id parameter is optional, but when sent with an empty string it is rejected by AWS. Changes include a clear way to provide optional parameters to the AWS CLI.